### PR TITLE
Fix typo in 'Error Handling' section

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt6.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt6.jade
@@ -159,7 +159,7 @@ code-example(format="." language="bash").
   In this demo service we log the error to the console; we should do better in real life.
 
   We've also decided to return a user friendly form of the error to
-  to the caller in a rejected promise so that the caller can display a proper error message to the user.
+  the caller in a rejected promise so that the caller can display a proper error message to the user.
 
   ### Promises are Promises
   Although we made significant *internal* changes to `getHeroes()`, the public signature did not change.


### PR DESCRIPTION
Remove duplicate 'to'